### PR TITLE
Dockerize app

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+*.o
+*.out
+*.txt
+.gitignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+### builder image
+FROM cpp-build-base:0.1.0 AS builder
+
+WORKDIR /app
+
+# copy code and complie
+COPY server server
+COPY shared shared
+COPY GNUmakefile .
+
+RUN make server
+
+### runtime image
+FROM debian:stable-slim
+
+COPY --from=builder /app/server.out .
+
+CMD ["./server.out"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,6 @@ FROM debian:stable-slim
 
 COPY --from=builder /app/server.out .
 
+EXPOSE 6169
+
 CMD ["./server.out"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ### builder image
-FROM cpp-build-base:0.1.0 AS builder
+FROM cpp-builder-base:latest AS builder
 
 WORKDIR /app
 

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,4 +1,4 @@
-server_objects = server.o game.o board.o changelog.o event.o server_api.o 
+server_objects = server.o game.o board.o changelog.o event.o server_api.o exitpipe.o
 client_objects = client.o client_api.o controller.o view.o
 shared_objects = board.o utilities.o
 
@@ -16,7 +16,7 @@ clean:
 	rm server.out client.out $(server_objects) $(client_objects) $(shared_objects)
 
 # server object file recipes
-server.o: server/server.cc server/server_api.hh server/game.hh
+server.o: server/server.cc server/server_api.hh
 	g++ -c server/server.cc -pthread -std=c++14
 
 game.o: server/game.cc server/changelog.hh server/event.hh shared/board.hh
@@ -28,8 +28,11 @@ changelog.o: server/changelog.cc server/event.hh
 event.o: server/event.cc
 	g++ -c server/event.cc -pthread -std=c++14
 
-server_api.o: server/server_api.cc server/game.hh
+server_api.o: server/server_api.cc server/game.hh server/exitpipe.hh
 	g++ -c server/server_api.cc -pthread -std=c++14
+
+exitpipe.o: server/exitpipe.cc
+	g++ -c server/exitpipe.cc -pthread -std=c++14
 
 # client object file recipes
 client.o: client/client.cc client/client_api.hh client/controller.hh shared/utilities.hh 

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -6,10 +6,10 @@ shared_objects = board.o utilities.o
 all: server client
 
 server: $(server_objects)
-	g++ -o server.out $(server_objects) -pthread
+	g++ -o server.out $(server_objects) -pthread -std=c++14
 
 client: $(client_objects) $(shared_objects)
-	g++ -o client.out $(client_objects) $(shared_objects) -pthread -lncurses
+	g++ -o client.out $(client_objects) $(shared_objects) -pthread -lncurses -std=c++14
 
 .PHONY : clean
 clean:
@@ -17,36 +17,36 @@ clean:
 
 # server object file recipes
 server.o: server/server.cc server/server_api.hh server/game.hh
-	g++ -c server/server.cc -pthread
+	g++ -c server/server.cc -pthread -std=c++14
 
 game.o: server/game.cc server/changelog.hh server/event.hh shared/board.hh
-	g++ -c server/game.cc -pthread
+	g++ -c server/game.cc -pthread -std=c++14
 
 changelog.o: server/changelog.cc server/event.hh
-	g++ -c server/changelog.cc -pthread
+	g++ -c server/changelog.cc -pthread -std=c++14
 
 event.o: server/event.cc
-	g++ -c server/event.cc -pthread
+	g++ -c server/event.cc -pthread -std=c++14
 
 server_api.o: server/server_api.cc server/game.hh
-	g++ -c server/server_api.cc -pthread
+	g++ -c server/server_api.cc -pthread -std=c++14
 
 # client object file recipes
 client.o: client/client.cc client/client_api.hh client/controller.hh shared/utilities.hh 
-	g++ -c client/client.cc -pthread -lncurses
+	g++ -c client/client.cc -pthread -lncurses -std=c++14
 
 client_api.o: client/client_api.cc client/controller.hh shared/utilities.hh  
-	g++ -c client/client_api.cc -pthread -lncurses
+	g++ -c client/client_api.cc -pthread -lncurses -std=c++14
 
 controller.o: client/controller.cc client/view.hh shared/board.hh
-	g++ -c client/controller.cc -pthread -lncurses
+	g++ -c client/controller.cc -pthread -lncurses -std=c++14
 
 view.o: client/view.cc shared/board.hh
-	g++ -c client/view.cc -pthread -lncurses
+	g++ -c client/view.cc -pthread -lncurses -std=c++14
 
 # shared object file recipes
 board.o: shared/board.cc
-	g++ -c shared/board.cc -pthread -lncurses
+	g++ -c shared/board.cc -pthread -lncurses -std=c++14
 
 utilities.o: shared/utilities.cc
-	g++ -c shared/utilities.cc -pthread -lncurses
+	g++ -c shared/utilities.cc -pthread -lncurses -std=c++14

--- a/README.md
+++ b/README.md
@@ -1,12 +1,21 @@
 # Pacman: multiplayer version of pacman
 Project developed in Linux (Ubuntu distribution). Not tested for MacOS / Windows.
 
+## Running the server:
+    Uses docker to build application.
+    1. Run `docker image build -t server-p .` to build the server
+    2. Run `docker run -p 6169:6169 server-p` to start the server
+
+    I have not yet build a way to terminate the server program + cleanup, so you will have to manually quit with "Ctrl-C"
+    You will need to manually stop the docker container to reopen the 6169 port, since force quitting does not stop the process.
+    As such, type `docker container ls`, which will give you the list of running containers. Note the ID of the server-p container
+    Type `docker container stop [ID]` to stop the container
+
 ## Project goal:
     Demonstrate competancy with C++ patterns and std
     Demonstrate competancy with concurrent programming (threads, mutexes, cvs)
     Demonstrate familiarity with basic systems / networking concepts 
     Demonstrate competancy with object oriented programming and polymorphism
-        NOTE: C++ is terrible for polymorphism
 
 ## Current status:
     The project currently allows multiple users to simultaneously connect to the server and move around a "Board". 

--- a/client/client.cc
+++ b/client/client.cc
@@ -41,7 +41,7 @@ int main(int argc , char *argv[]) {
 	// get the board from the server, reading BUFSIZ at a time
 	int n_read = recv(sfd, server_msg, BUFSIZ, 0); 
 	if (n_read < 0) {
-		std::cerr << " Shutting down..." << std::endl;
+		std::cerr << " Shutting down." << std::endl;
 		close(sfd);
 		return 1;
 	}

--- a/client/client.cc
+++ b/client/client.cc
@@ -14,6 +14,7 @@ using json = nlohmann::json;
 
 int main(int argc , char *argv[]) {
 	
+	// TODO - these need to be passes as arguments to init_socket()
 	int port;
 	char* path;
 
@@ -26,7 +27,7 @@ int main(int argc , char *argv[]) {
 	}
 
 	// init and connect to socket
-	int sfd = init_socket(); 
+	int sfd = init_socket(port, path); 
     if (sfd == -1) {
 		std::cerr << "Shutting down." << std::endl;
 		return 1;

--- a/client/client.cc
+++ b/client/client.cc
@@ -29,7 +29,7 @@ int main(int argc , char *argv[]) {
 	// init and connect to socket
 	int sfd = init_socket(port, path); 
     if (sfd == -1) {
-		std::cerr << "Shutting down." << std::endl;
+		std::cerr << "Error: failed to init socket." << std::endl;
 		return 1;
 	}
 
@@ -41,7 +41,7 @@ int main(int argc , char *argv[]) {
 	// get the board from the server, reading BUFSIZ at a time
 	int n_read = recv(sfd, server_msg, BUFSIZ, 0); 
 	if (n_read < 0) {
-		std::cerr << " Shutting down." << std::endl;
+		std::cerr << "Error: recv failed." << std::endl;
 		close(sfd);
 		return 1;
 	}

--- a/client/client.cc
+++ b/client/client.cc
@@ -13,6 +13,8 @@ using json = nlohmann::json;
 
 int main(int argc , char *argv[]) {
 
+	std::cout << path << std::endl;
+
 	// init and connect to socket
 	int sfd = init_socket(); 
     if (sfd == -1) {

--- a/client/client.cc
+++ b/client/client.cc
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <cstdlib>
 #include <thread>
 #include <string>
 #include <tuple>
@@ -12,8 +13,17 @@
 using json = nlohmann::json;
 
 int main(int argc , char *argv[]) {
+	
+	int port;
+	char* path;
 
-	std::cout << path << std::endl;
+	if (argc != 3) {
+		std::cout << "usage: ./client [server-ip] [port]" << std::endl;
+		return 0;
+	} else {
+		path = argv[1];
+		port = atoi(argv[2]);
+	}
 
 	// init and connect to socket
 	int sfd = init_socket(); 

--- a/client/client_api.cc
+++ b/client/client_api.cc
@@ -26,7 +26,7 @@ void handle_user_input(int sfd, Controller* c_ptr) {
 
 		if (send(sfd, msg.c_str(), msg.size(), 0) < 0)	{
 			c_ptr->set_quit();
-			ofs << "Send move request failed" << std::endl;
+			ofs << "Send move request failed." << std::endl;
 			return;
 		}
 
@@ -37,10 +37,10 @@ void handle_user_input(int sfd, Controller* c_ptr) {
 	// if the user sent "q", send a quit request
 	c_ptr->set_quit();
 	std::string msg = format_client_quit_request();
-	ofs << msg << std::endl;
+	ofs << "sending quit message: " << msg << std::endl;
 
 	if (send(sfd, msg.c_str(), msg.size(), 0) < 0)	{
-		ofs << "Send quit request failed" << std::endl;
+		ofs << "Send quit request failed." << std::endl;
 		return;
 	}
 
@@ -56,13 +56,17 @@ void handle_user_input(int sfd, Controller* c_ptr) {
 void handle_changelog(int sfd, Controller* c_ptr) {
 
 	std::ofstream ofs;
-	ofs.open("changelog_output.txt", std::ofstream::out | std::ofstream::app);
+	char name[50];
+	int n = sprintf(name, "changelog_output_%d.txt", c_ptr->player_id);
+	ofs.open(name, std::ofstream::out | std::ofstream::app);
 
 	// loop, listening to the server for changelog updates
 	char server_msg[BUFSIZ];
 
 	// TOOD: update this to have some atomic that user is still connected
 	while(true) {
+
+		ofs << "before recv" << std::endl;
 
 		// read the message from the server
 		if (recv(sfd, server_msg, BUFSIZ, 0) <= 0) {
@@ -75,6 +79,7 @@ void handle_changelog(int sfd, Controller* c_ptr) {
 		// check if the UI has suggested that we should quit before
 		// if it has, then we will eventually get here (since user quitting is an event)
 		if (c_ptr->should_quit()) {
+			ofs << "quitting" << std::endl;
 			ofs.close();
 			return;
 		}

--- a/client/client_api.cc
+++ b/client/client_api.cc
@@ -135,7 +135,7 @@ bool handle_event(json event_json, Controller* c_ptr) {
 //      initializes and connects to socket
 //      returns a socket fd (if == -1, there was an error)
 
-int init_socket() {
+int init_socket(const int port, const char* path) {
     int sfd;
 	struct sockaddr_in server;
 	

--- a/client/client_api.cc
+++ b/client/client_api.cc
@@ -11,7 +11,8 @@ using json = nlohmann::json;
 //			
 
 void handle_user_input(int sfd, Controller* c_ptr) { 	
-	freopen("output.txt", "w", stderr);
+	std::ofstream ofs;
+	ofs.open("user_input.txt", std::ofstream::out | std::ofstream::app);
 
 	// get move from the user
 	char key = c_ptr->get_next_move();
@@ -21,11 +22,11 @@ void handle_user_input(int sfd, Controller* c_ptr) {
 		
 		// format message and send to server
 		std::string msg = format_client_move_request(key);
-		std::cerr << msg << std::endl;
+		ofs << msg.c_str() << std::endl;
 
 		if (send(sfd, msg.c_str(), msg.size(), 0) < 0)	{
 			c_ptr->set_quit();
-			std::cerr << "Send move request failed" << std::endl;
+			ofs << "Send move request failed" << std::endl;
 			return;
 		}
 
@@ -36,13 +37,14 @@ void handle_user_input(int sfd, Controller* c_ptr) {
 	// if the user sent "q", send a quit request
 	c_ptr->set_quit();
 	std::string msg = format_client_quit_request();
-	std::cerr << msg << std::endl;
+	ofs << msg << std::endl;
 
 	if (send(sfd, msg.c_str(), msg.size(), 0) < 0)	{
-		std::cerr << "Send quit request failed" << std::endl;
+		ofs << "Send quit request failed" << std::endl;
 		return;
 	}
 
+	ofs.close();
 	return;
 }
 
@@ -52,7 +54,10 @@ void handle_user_input(int sfd, Controller* c_ptr) {
 //		TODO: update to santize the raw server message
 
 void handle_changelog(int sfd, Controller* c_ptr) {
-	
+
+	std::ofstream ofs;
+	ofs.open("changelog_output.txt", std::ofstream::out | std::ofstream::app);
+
 	// loop, listening to the server for changelog updates
 	char server_msg[BUFSIZ];
 
@@ -62,13 +67,15 @@ void handle_changelog(int sfd, Controller* c_ptr) {
 		// read the message from the server
 		if (recv(sfd, server_msg, BUFSIZ, 0) <= 0) {
 			c_ptr->set_quit(); 
-			std::cerr << "ERROR: Read from server." << std::endl;
+			ofs << "ERROR: Read from server." << std::endl;
+			ofs.close();
 			return;
 		}
 		
 		// check if the UI has suggested that we should quit before
 		// if it has, then we will eventually get here (since user quitting is an event)
 		if (c_ptr->should_quit()) {
+			ofs.close();
 			return;
 		}
 		
@@ -77,9 +84,13 @@ void handle_changelog(int sfd, Controller* c_ptr) {
 		std::string event_str;
 		int n_left;
 		std::tie(event_str, n_left) = parse_message(server_msg, server_event_format, body_format, body_keyword_len);
+		
+		ofs << event_str << std::endl;
+
 		if(!handle_event(json::parse(event_str), c_ptr)) {
 			c_ptr->set_quit(); 
-			std::cerr << "ERROR: Event invalid." << std::endl;
+			ofs << "ERROR: Event invalid." << std::endl;
+			ofs.close();
 			return;
 		}
 	}

--- a/client/client_api.cc
+++ b/client/client_api.cc
@@ -26,7 +26,7 @@ void handle_user_input(int sfd, Controller* c_ptr) {
 
 		if (send(sfd, msg.c_str(), msg.size(), 0) < 0)	{
 			c_ptr->set_quit();
-			ofs << "Send move request failed." << std::endl;
+			ofs << "Error: send move request failed." << std::endl;
 			return;
 		}
 
@@ -37,10 +37,8 @@ void handle_user_input(int sfd, Controller* c_ptr) {
 	// if the user sent "q", send a quit request
 	c_ptr->set_quit();
 	std::string msg = format_client_quit_request();
-	ofs << "sending quit message: " << msg << std::endl;
-
 	if (send(sfd, msg.c_str(), msg.size(), 0) < 0)	{
-		ofs << "Send quit request failed." << std::endl;
+		ofs << "Error: send quit request failed." << std::endl;
 		return;
 	}
 
@@ -56,9 +54,7 @@ void handle_user_input(int sfd, Controller* c_ptr) {
 void handle_changelog(int sfd, Controller* c_ptr) {
 
 	std::ofstream ofs;
-	char name[50];
-	int n = sprintf(name, "changelog_output_%d.txt", c_ptr->player_id);
-	ofs.open(name, std::ofstream::out | std::ofstream::app);
+	ofs.open("changelog.txt", std::ofstream::out | std::ofstream::app);
 
 	// loop, listening to the server for changelog updates
 	char server_msg[BUFSIZ];
@@ -95,6 +91,7 @@ void handle_changelog(int sfd, Controller* c_ptr) {
 		if(!handle_event(json::parse(event_str), c_ptr)) {
 			c_ptr->set_quit(); 
 			ofs << "ERROR: Event invalid." << std::endl;
+			ofs << "here" << std::endl;
 			ofs.close();
 			return;
 		}
@@ -106,6 +103,10 @@ void handle_changelog(int sfd, Controller* c_ptr) {
 //			(A) move:	moves the player in the board
 //			(B) add:	adds a new player to the board
 //			(C) quit:	removes a player from the board
+//			(D) exit: 	exits the game
+//		return value:
+//			true: json was a valid event
+//			false: json was an invalid event
 
 bool handle_event(json event_json, Controller* c_ptr) {
 
@@ -124,6 +125,12 @@ bool handle_event(json event_json, Controller* c_ptr) {
 	// (C) handle quit
 	if (event_json.find("quit") != event_json.end()) {
 		c_ptr->handle_event_quit(event_json["quit"]["pid"], event_json["quit"]["loc"]);
+		return true;
+	}
+
+	// (D) TODO: handle exit
+	if (event_json.find("quit") != event_json.end()) {
+		c_ptr->handle_event_exit();
 		return true;
 	}
 

--- a/client/client_api.hh
+++ b/client/client_api.hh
@@ -24,10 +24,6 @@ static const int body_keyword_len = 5;
 static const char* body_format = "body=";
 static const char* body_header =", body=";
 
-static const int port = 6169;
-// static const char* path = "18.222.48.92";
-static const char* path = "127.0.0.1";
-
 void handle_user_input(int sfd, Controller* c_ptr);
 void handle_changelog(int sfd, Controller* c_ptr);
 bool handle_event(nlohmann::json event_json, Controller* c_ptr);

--- a/client/client_api.hh
+++ b/client/client_api.hh
@@ -32,7 +32,7 @@ bool handle_event(nlohmann::json event_json, Controller* c_ptr);
 //      wrapper around C socket syscalls
 //      initializes and connects to socket
 //      returns a sfd (if < 0, there was an error)
-int init_socket();
+int init_socket(const int port, const char* path);
 
 // std::String add_request_wrapper(std::string body_str)
 //		wrapes the body of the message in the correcet protocol

--- a/client/client_api.hh
+++ b/client/client_api.hh
@@ -26,6 +26,17 @@ static const char* body_header =", body=";
 
 void handle_user_input(int sfd, Controller* c_ptr);
 void handle_changelog(int sfd, Controller* c_ptr);
+
+// bool handle_event(json event_json, Controller* c_ptr)
+//		handles the events from the raw json format, passing to the controller:
+//			(A) move:	moves the player in the board
+//			(B) add:	adds a new player to the board
+//			(C) quit:	removes a player from the board
+//			(D) exit: 	exits the game
+//		return value:
+//			true: json was a valid event
+//			false: json was an invalid event
+
 bool handle_event(nlohmann::json event_json, Controller* c_ptr);
 
 // int init socket

--- a/client/client_api.hh
+++ b/client/client_api.hh
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <fstream>
 #include <string>
 #include <sys/socket.h> // socket
 #include <arpa/inet.h>	// inet_addr
@@ -24,6 +25,7 @@ static const char* body_format = "body=";
 static const char* body_header =", body=";
 
 static const int port = 6169;
+// static const char* path = "18.222.48.92";
 static const char* path = "127.0.0.1";
 
 void handle_user_input(int sfd, Controller* c_ptr);

--- a/client/controller.cc
+++ b/client/controller.cc
@@ -82,6 +82,11 @@ void Controller::handle_event_quit(int pid, int loc) {
     view_.update_cell(loc, -1);
 }
 
+void Controller::handle_event_exit() {
+    // evil hack - the handle_user_request() thread is listening on getch(). so i write to stdin to get it to breakout
+    // since this code will be moved to js, i am just leaving this for the time being so i have a working commandline version
+    write(STDIN_FILENO, "q", 1);
+}
 
 // QUIT STATE
 //      gets and sets the "quit" state

--- a/client/controller.hh
+++ b/client/controller.hh
@@ -27,6 +27,7 @@ class Controller {
 
         bool should_quit();
         void set_quit();
+        int player_id; 
 
     private:
         FILE* log_fp;
@@ -36,7 +37,7 @@ class Controller {
         View view_;
 
         // id of the player on this client
-        int player_id; 
+        // int player_id; 
     
         bool quit;
 };

--- a/client/controller.hh
+++ b/client/controller.hh
@@ -3,6 +3,7 @@
 
 #include <cstdio>
 #include <string>
+#include <unistd.h> // dirty evil hacking
 #include "../shared/nlohmann/json.hpp"
 
 #include "../shared/board.hh"
@@ -24,10 +25,10 @@ class Controller {
         void handle_event_move(int pid, int dir);
         void handle_event_add(int pid, int loc);
         void handle_event_quit(int pid, int loc);
+        void handle_event_exit();
 
         bool should_quit();
         void set_quit();
-        int player_id; 
 
     private:
         FILE* log_fp;
@@ -37,7 +38,7 @@ class Controller {
         View view_;
 
         // id of the player on this client
-        // int player_id; 
+        int player_id; 
     
         bool quit;
 };

--- a/server/event.cc
+++ b/server/event.cc
@@ -1,6 +1,6 @@
 #include "event.hh"
 
-// Move, Add, Quit inherit from abstract class Event (virtual)
+// Move, Add, Quit, Exit inherit from abstract class Event (virtual)
 //      this file defines the virtual method (get_json) for each child class
 //      then, use the ptr pattern to implement polymorphism 
 
@@ -24,5 +24,12 @@ nlohmann::json Quit::get_json() {
     nlohmann::json j;
     j["quit"]["pid"] = player_id;
     j["quit"]["loc"] = modifier;
+    return j;
+}
+
+nlohmann::json Exit::get_json() {
+    nlohmann::json j;
+    j["exit"]["pid"] = player_id;
+    j["exit"]["loc"] = modifier;
     return j;
 }

--- a/server/event.hh
+++ b/server/event.hh
@@ -11,8 +11,9 @@ class Event {
         virtual nlohmann::json get_json() = 0;
 
         // checks if the json form of the event is a quit for player_id 
-        static bool is_exit_event(nlohmann::json e_json) {
-            return e_json.find("quit") != e_json.end() || e_json.find("exit") != e_json.end();
+        static bool is_exit_event(nlohmann::json e_json, int player_id) {
+            return (e_json.find("quit") != e_json.end() && e_json["quit"]["pid"] == player_id) 
+                || e_json.find("exit") != e_json.end();
         } 
 
         int player_id;

--- a/server/event.hh
+++ b/server/event.hh
@@ -11,31 +11,37 @@ class Event {
         virtual nlohmann::json get_json() = 0;
 
         // checks if the json form of the event is a quit for player_id 
-        static bool is_quit_event(int player_id, nlohmann::json e_json) {
-            if (e_json.find("quit") == e_json.end()) {
-                return false;
-            } else {
-                return e_json["quit"]["pid"] == player_id;
-            }
+        static bool is_exit_event(nlohmann::json e_json) {
+            return e_json.find("quit") != e_json.end() || e_json.find("exit") != e_json.end();
         } 
 
         int player_id;
         int modifier;   
 };
 
+// player moves
 class Move : public Event {
     public:
         using Event::Event;
         nlohmann::json get_json();
 };
 
+// player added to game
 class Add : public Event {
     public:
         using Event::Event;
         nlohmann::json get_json();
 };
 
+// player quits the game
 class Quit : public Event {
+    public:
+        using Event::Event;
+        nlohmann::json get_json();
+};
+
+// game is exited
+class Exit : public Event {
     public:
         using Event::Event;
         nlohmann::json get_json();

--- a/server/exitpipe.cc
+++ b/server/exitpipe.cc
@@ -9,8 +9,8 @@ void Exitpipe::add_fd_pair() {
 
     // setup pipes for both the request handler + the changelpg handler
     pipe_fd_pair_t fd_pair;
-    fd_pair.writer = pfds[0];
-    fd_pair.reader = pfds[1];
+    fd_pair.writer = pfds[1];
+    fd_pair.reader = pfds[0];
     fd_pairs.push_back(fd_pair);
 
     return;
@@ -20,8 +20,25 @@ int Exitpipe::pop_reader_fd() {
     return fd_pairs.back().reader;
 }
 
-void Exitpipe::cleanup_writers() { 
+void Exitpipe::exit_all() { 
     for (pipe_fd_pair_t fd_pair : fd_pairs) {
-        close(fd_pair.writer);
+        char wbuf[BUFSIZ];
+        sprintf(wbuf, "exit");
+        size_t n = write(fd_pair.writer, wbuf, strlen(wbuf));
+        std::cout << "wrote n = " << std::to_string(n) << " bytes to pipe" << std::endl;
+    }
+}
+
+void Exitpipe::close_all() { 
+    for (pipe_fd_pair_t fd_pair : fd_pairs) {
+        int r = close(fd_pair.reader);
+        if (r != 0) {
+            std::cerr << "Error: error closing reader end of exit pipe" << std::endl;
+        }
+        
+        int q = close(fd_pair.writer);
+        if (q != 0) {
+            std::cerr << "Error: error closing writer end of exit pipe" << std::endl;
+        }
     }
 }

--- a/server/exitpipe.cc
+++ b/server/exitpipe.cc
@@ -25,7 +25,6 @@ void Exitpipe::exit_all() {
         char wbuf[BUFSIZ];
         sprintf(wbuf, "exit");
         size_t n = write(fd_pair.writer, wbuf, strlen(wbuf));
-        std::cout << "wrote n = " << std::to_string(n) << " bytes to pipe" << std::endl;
     }
 }
 

--- a/server/exitpipe.cc
+++ b/server/exitpipe.cc
@@ -1,0 +1,27 @@
+#include "exitpipe.hh"
+
+void Exitpipe::add_fd_pair() { 
+    int pfds[2];
+    int r = pipe(pfds);
+    if (r != 0) {
+        // TODO: handle error
+    } 
+
+    // setup pipes for both the request handler + the changelpg handler
+    pipe_fd_pair_t fd_pair;
+    fd_pair.writer = pfds[0];
+    fd_pair.reader = pfds[1];
+    fd_pairs.push_back(fd_pair);
+
+    return;
+}
+
+int Exitpipe::pop_reader_fd() { 
+    return fd_pairs.back().reader;
+}
+
+void Exitpipe::cleanup_writers() { 
+    for (pipe_fd_pair_t fd_pair : fd_pairs) {
+        close(fd_pair.writer);
+    }
+}

--- a/server/exitpipe.hh
+++ b/server/exitpipe.hh
@@ -1,0 +1,23 @@
+#ifndef EXITPIPE_H
+#define EXIT_PIPE_H
+
+#include <vector>
+#include <unistd.h>
+
+struct pipe_fd_pair_t {
+    int reader;
+    int writer;
+};
+
+class Exitpipe {
+    public:
+        void add_fd_pair();
+        int pop_reader_fd();
+        void cleanup_writers();
+
+    private:
+        std::vector<pipe_fd_pair_t> fd_pairs;
+};
+
+
+#endif

--- a/server/exitpipe.hh
+++ b/server/exitpipe.hh
@@ -1,8 +1,10 @@
 #ifndef EXITPIPE_H
-#define EXIT_PIPE_H
+#define EXITPIPE_H
 
 #include <vector>
 #include <unistd.h>
+#include <cstring>
+#include <iostream>
 
 struct pipe_fd_pair_t {
     int reader;
@@ -13,7 +15,8 @@ class Exitpipe {
     public:
         void add_fd_pair();
         int pop_reader_fd();
-        void cleanup_writers();
+        void exit_all();
+        void close_all();
 
     private:
         std::vector<pipe_fd_pair_t> fd_pairs;

--- a/server/game.cc
+++ b/server/game.cc
@@ -131,7 +131,6 @@ void Game::handle_request_quit(int player_id) {
     int loc = board_.delete_player(player_id);
     if(loc != -1) {
         changelog_.push(std::make_unique<Quit>(Quit(player_id, loc)));
-        std::cout << "pushing quit to the changelog ... " << std::endl;
         lock_cl.unlock();
         cl_cv.notify_all();
     }

--- a/server/game.cc
+++ b/server/game.cc
@@ -56,8 +56,8 @@ json Game::get_next_event(int player_id) {
 // bool is_exit_event(json e_json):
 //      checks if the event should result in an exit (e.g. quit / exit)
 
-bool Game::is_exit_event(json e_json) {
-    return Event::is_exit_event(e_json);
+bool Game::is_exit_event(json e_json, int player_id) {
+    return Event::is_exit_event(e_json, player_id);
 }
 
 // int handle_add_player (int cfd)

--- a/server/game.cc
+++ b/server/game.cc
@@ -131,6 +131,7 @@ void Game::handle_request_quit(int player_id) {
     int loc = board_.delete_player(player_id);
     if(loc != -1) {
         changelog_.push(std::make_unique<Quit>(Quit(player_id, loc)));
+        std::cout << "pushing quit to the changelog ... " << std::endl;
         lock_cl.unlock();
         cl_cv.notify_all();
     }

--- a/server/game.hh
+++ b/server/game.hh
@@ -44,7 +44,7 @@ class Game {
 
         // wrapper around changelog API, implementing synchronization - gets json of next event
         nlohmann::json get_next_event(int player_id);
-        bool is_exit_event(nlohmann::json e_json);
+        bool is_exit_event(nlohmann::json e_json, int player_id);
 
         // outputting / displaying state
         void print_board(); 

--- a/server/game.hh
+++ b/server/game.hh
@@ -14,7 +14,7 @@
 #include "event.hh"
 #include "../shared/board.hh"
 
-// Server Kernel - holds the data structures and implements synchronization
+// Game Kernel - holds the data structures and implements synchronization
 //
 //      Data Structures(private):
 //          board_: holds the actual graph represening the gameboard
@@ -39,21 +39,21 @@ class Game {
         // wrappers around the board API, implementing synchronization
         std::tuple<int, nlohmann::json> handle_add_player (int cfd);
         void handle_request_move(int player_id, int dir);
-        void handle_request_quit(int playe_id);
-        bool has_quit(int player_id);
+        void handle_request_quit(int player_id);
+        void handle_request_exit(int player_id);
 
         // wrapper around changelog API, implementing synchronization - gets json of next event
         nlohmann::json get_next_event(int player_id);
-        bool is_quit_event(int player_id, nlohmann::json e_json);
-        
+        bool is_exit_event(nlohmann::json e_json);
+
         // outputting / displaying state
         void print_board(); 
         nlohmann::json get_board_json();
 
-
     private:
         int n_players;                  // count of the number of players
-        
+        bool exit_condition;            // exit condition to exit the game
+
         // synchronization objects
         std::mutex b_mutex;             // mutex used for the board_
         std::mutex cl_mutex;            // mutex used for the changelog_

--- a/server/server.cc
+++ b/server/server.cc
@@ -8,7 +8,6 @@
 #include "../shared/nlohmann/json.hpp"
 
 #include "server_api.hh"
-//#include "game.hh"
 
 static const int port = 6169;
 static const int board_size = 21;
@@ -16,73 +15,175 @@ static const int max_players = 5;
 
 using json = nlohmann::json;
 
-int main(int argc, char** argv) {
-
-    // create socket, bind, and listen 
-    int sfd = init_socket(port, max_players);
-    if (sfd == -1) {
-        std::cout << "Could not init socket...shutting down\n";
-        return 1;
-    } else {
-        std::cout << "Listening on port " << std::to_string(port) << "..." << std::endl;
-    }
-
-    // create game obj, which will hold the shared state
-    Game game_(board_size);
+void run_server(int sfd, int exit_pipe_fd) {
     
-    // create exitpipe obj, which will be use to tell worker threads to exit, if ended
-    Exitpipe exitpipe_;
-
-    // create vector of connection threads to handle each user
+    // init game objects + connection objects
+    Game game_(board_size);
+    Exitpipe exitpipe_;                     
     std::vector<std::thread> connections;
 
-    // vars used for the socket
-    socklen_t c = sizeof(struct sockaddr);
+    // vars for the main loop below
     struct sockaddr_in client;
+    socklen_t c = sizeof(struct sockaddr);
     int player_id;
     json board_json;
 
-    // accept client connection + spin off connection threads until exit
+    fd_set readfds;
+    int max_fd = sfd > exit_pipe_fd ? sfd : exit_pipe_fd;
+
     bool is_exited = false;
+
+    // accept client connection + spin off connection threads until exit
     while(!is_exited) {
+        std::cout << "before select" << std::endl;
+        FD_ZERO(&readfds);
+        FD_SET(exit_pipe_fd, &readfds);    // add exit signal pipe
+        FD_SET(sfd, &readfds);             // add the socket
 
         // accept new connections
-        int cfd = accept(sfd, (sockaddr*) &client, &c);
-        if (cfd < 0) {
+        int r = select(max_fd + 1 , &readfds , NULL , NULL , NULL);
 
-            // TODO: tell threads that we are dead + that it should shut down
-            perror("accept");
-            close(cfd);
-            close(sfd);
-            return 1;
-        }
-
-        // add a new pipe pair
-        exitpipe_.add_fd_pair();
+        std::cout << "after select" << std::endl;
         
-        // create player + launch connection threads
-        std::tie(player_id, board_json) = game_.handle_add_player(cfd);
-        connections.push_back(std::thread(handle_connection, cfd, exitpipe_.pop_reader_fd(), player_id, &game_, board_json));
+        if (r < 0) {
+            std::cerr << "TODO: shutdown the board on error";
+        } else if (r == 0) {
+            std::cerr << "should not get here";
+        } else if (FD_ISSET(exit_pipe_fd, &readfds)) {
+            is_exited = true;
+            char rbuf[BUFSIZ];
+            
+            size_t n = read(exit_pipe_fd, rbuf, BUFSIZ);
+            assert(n >= 0);
+            rbuf[n] = 0;
+
+            printf("Read %s\n", rbuf);
+
+        } else {
+            // std::cout << "here2" << std::endl;
+            assert(FD_ISSET(sfd, &readfds));
+            int cfd = accept(sfd, (sockaddr*) &client, &c);
+            if (cfd < 0) {
+
+                // TODO: tell threads that we are dead + that it should shut down
+                perror("accept");
+                close(cfd);
+                close(sfd);
+                return;
+            }
+
+            // add a new pipe pair
+            exitpipe_.add_fd_pair();
+            
+            // create player + launch connection threads
+            std::tie(player_id, board_json) = game_.handle_add_player(cfd);
+            connections.push_back(std::thread(handle_connection, cfd, exitpipe_.pop_reader_fd(), player_id, &game_, board_json));
+        }
     } 
 
-    // close the exit notification pipes
-    exitpipe_.cleanup_writers();
+    // send signal to the connection threads that it is time to close
+    exitpipe_.exit_all();
 
     // join connection threads back together
     for (std::thread & connection : connections) {
         if (connection.joinable()) {
-            std::cout << "Joining thread " << connection.get_id() << std::endl;
+            std::cout << "Joining thread " << connection.get_id() << "...";
             connection.join();
+            std::cout << "[DONE]" << std::endl;
         } else {
             // should not get here
             std::cerr << "Error: Thread " << connection.get_id() << " could not be joined" << std::endl;
         }
     }
 
+    // cleanup all the exit pipe resources
+    exitpipe_.close_all();
+    close(exit_pipe_fd);
+
     // close the sfd    
     shutdown(sfd, SHUT_RDWR);
     if(close(sfd) < 0) {
         std::cerr << "Error: close failed for sfd:" << std::endl;
     }
+}
+
+int main(int argc, char** argv) {
+
+    // initialzie socket
+    std::cout << "Initializing socket ...";    
+    int sfd = init_socket(port, max_players);
+    if (sfd == -1) {
+        std::cout << "[FAILED] ... Shutting down\n" << std::endl;
+        return 1;
+    } else {
+        std::cout << "[DONE] ... Listening on port " << std::to_string(port) << std::endl;
+    }
+
+    // initialize game, spinning off a thread to run the game server
+    //      create a pipe to send exit messages from the active process to the run_server thread
+    std::cout << "Initializing game ...";
+    int pfds[2];
+    if (pipe(pfds) != 0) {
+        std::cerr << "Error opening pipe for main server thread ... shutting down." << std::endl;
+        return 0;
+    }
+
+    std::thread server_t  = std::thread(run_server, sfd, pfds[0]);
+    std::cout << "[DONE]"<< std::endl;
+
+    // listen for commands from the command line
+    FILE* command_file = stdin;
+
+    char buf[BUFSIZ];
+    int bufpos = 0;
+    bool needprompt = true;
+    bool exited = false;
+
+    while (!exited && !feof(command_file)) {
+        
+        // print the prompt at the beginning of the line
+        if (needprompt) {
+            std::cout << "pacman$ ";
+            fflush(stdout);
+            needprompt = false;
+        }
+
+        // read a string, checking for error or EOF
+        if (fgets(&buf[bufpos], BUFSIZ - bufpos, command_file) == nullptr) {
+            if (ferror(command_file) && errno == EINTR) {
+                // ignore EINTR errors
+                clearerr(command_file);
+                buf[bufpos] = 0;
+            } else {
+                if (ferror(command_file)) {
+                    perror("sh61");
+                }
+                break;
+            }
+        }
+
+        // if a complete command line has been provided, run it
+        bufpos = strlen(buf);
+        if (bufpos == BUFSIZ - 1 || (bufpos > 0 && buf[bufpos - 1] == '\n')) {
+            std::string cmd(buf); 
+            std::cout << cmd.substr(0,4) << std::endl;
+            if (cmd.substr(0,4) == "exit") {
+
+                std::cout << "in exit" << std::endl;
+                char wbuf[BUFSIZ];
+                sprintf(wbuf, "exit");
+                size_t n = write(pfds[1], wbuf, strlen(wbuf));
+                std::cout << "wrote n = " << std::to_string(n) << " bytes to pipe" << std::endl;
+                exited = true;
+                
+            }
+            bufpos = 0;
+            needprompt = true;
+        }
+    }
+
+    server_t.join();
+    close(pfds[1]);
+
 	return 0;
 }

--- a/server/server.cc
+++ b/server/server.cc
@@ -52,9 +52,8 @@ int main(int argc, char** argv) {
 
         // create player + launch thread to listen to CL + Player Commands
         std::tie(player_id, board_json) = game_.handle_add_player(cfd);
-        std::thread t(handle_connection, cfd, player_id, &game_, board_json);
-        t.detach();
-
+        std::thread conn_t(handle_connection, cfd, player_id, &game_, board_json);
+        conn_t.detach();
     } 
 
     close(sfd);

--- a/server/server_api.cc
+++ b/server/server_api.cc
@@ -114,7 +114,6 @@ void handle_requests(int cfd, int player_id, Game* g_ptr) {
                 
                 // move the buffer pointer over to the start of the next request, update skip flag
                 buf_ptr += body_start_ind + len;
-                std::cout << "buf ptr before skip_get = " << buf_ptr << std::endl;
                 skip_get = (sscanf(buf_ptr, client_request_format, &len, &equals_sign) == 2 && equals_sign == '=');
 
                 // reset the buf ptr back to the start of the buffer    
@@ -125,7 +124,6 @@ void handle_requests(int cfd, int player_id, Game* g_ptr) {
 
             // IF (buffer did not contain the entire request), read until we have the whole thing
             } else {
-                std::cout << "here" << std::endl;
                 buf_ptr = buf;
                 skip_get = false;
                 while (request.size() < len) {
@@ -162,8 +160,6 @@ void handle_requests(int cfd, int player_id, Game* g_ptr) {
 //          2)  "quit":1     ---> 1 = value for protocol consistency (removes the player from the board) 
 
 bool handle_request(json request, int cfd, int player_id, Game* g_ptr) {
-
-    std::cout << request.dump() << std::endl;
     
     std::string response;
     bool is_quit = false;

--- a/server/server_api.cc
+++ b/server/server_api.cc
@@ -60,7 +60,7 @@ void handle_connection(int cfd, int player_id, Game* g_ptr, json board_json) {
     t.join();
     shutdown(cfd, SHUT_RDWR);
     if(close(cfd) < 0) {
-        std::cout << "cLose failed" << std::endl;
+        std::cerr << "cLose failed" << std::endl;
     }
 
     return;
@@ -86,13 +86,13 @@ void handle_requests(int cfd, int player_id, Game* g_ptr) {
     char equals_sign;
     std::string request;
 
-    g_ptr->print_board();
-    std::cout << std::endl;
+    // g_ptr->print_board();
+    // std::cout << std::endl;
    
     // read the client request from the file
     //      skip_get == true when we know there is already a well formed header already in buf
     while (skip_get || recv(cfd, buf_ptr, BUFSIZ - (buf_ptr - buf), 0) > 0) {    
-
+        
         // parse the request of form REQUEST len=XXX, body=YYY      
         if (sscanf(buf_ptr, client_request_format, &len, &equals_sign) == 2 && equals_sign == '=') {
             
@@ -114,10 +114,18 @@ void handle_requests(int cfd, int player_id, Game* g_ptr) {
                 
                 // move the buffer pointer over to the start of the next request, update skip flag
                 buf_ptr += body_start_ind + len;
+                std::cout << "buf ptr before skip_get = " << buf_ptr << std::endl;
                 skip_get = (sscanf(buf_ptr, client_request_format, &len, &equals_sign) == 2 && equals_sign == '=');
+
+                // reset the buf ptr back to the start of the buffer    
+                if (!skip_get) {
+                    memset(buf, '\0', BUFSIZ); // clears out memory
+                    buf_ptr = buf;
+                }
 
             // IF (buffer did not contain the entire request), read until we have the whole thing
             } else {
+                std::cout << "here" << std::endl;
                 buf_ptr = buf;
                 skip_get = false;
                 while (request.size() < len) {
@@ -139,6 +147,8 @@ void handle_requests(int cfd, int player_id, Game* g_ptr) {
         // IF the request does not conform to the API, return some type of error
         } else {
             // TODO: return some type of error
+            std::cout << "ERROR!" << std::endl;
+            return;
         }
     }
 
@@ -153,6 +163,8 @@ void handle_requests(int cfd, int player_id, Game* g_ptr) {
 
 bool handle_request(json request, int cfd, int player_id, Game* g_ptr) {
 
+    std::cout << request.dump() << std::endl;
+    
     std::string response;
     bool is_quit = false;
 
@@ -173,8 +185,8 @@ bool handle_request(json request, int cfd, int player_id, Game* g_ptr) {
 	}
     
     // print board out for the time being to observe state
-    g_ptr->print_board();
-    std::cout << std::endl;
+    // g_ptr->print_board();
+    // std::cout << std::endl;
 
     return is_quit;
 }

--- a/server/server_api.hh
+++ b/server/server_api.hh
@@ -105,6 +105,13 @@ std::string format_server_msg(nlohmann::json command, const char* header, const 
 
 bool write_to_socket(int cfd, std::string msg);
 
+// read_from_socket(cfd, buf_ptr, sz):
+//      reads from socket, blocking
+//      returns true if there is text to read from buf_ptr
+//      returns false if there is none (i.e. socket connection closed)
+
+bool read_from_socket(int cfd, char* buf_ptr, int sz);
+
 // int init_socket(port, max_conns)
 //      connect, binds, listens 
 //      binds to port
@@ -112,6 +119,5 @@ bool write_to_socket(int cfd, std::string msg);
 //      returns a socket fd; returns -1 if there was an error
 
 int init_socket(int port, int max_conns);
-
 
 #endif

--- a/server/server_api.hh
+++ b/server/server_api.hh
@@ -77,6 +77,14 @@ void handle_requests(int cfd, int exit_pipe_cfd, int player_id, Game* g_ptr);
 
 bool handle_request(nlohmann::json request, int cfd, int player_id, Game* g_ptr);
 
+// parse_request(buf_ptr, request)
+//      parses the request according to the API from the buffer
+//      buf_ptr, request are passed by REFERENCE + state is updated
+//          returns true if there was a request to process
+//          returns false if there was a non-conforming request
+
+bool parse_request(char*& buf_ptr, std::string& request)
+
 //
 // (2) CHANGELOG EVENTS
 //
@@ -98,6 +106,18 @@ std::string format_server_msg(nlohmann::json command, const char* header, const 
 // ********** SYSCALL WRAPPERS **********
 //
 //
+
+// is_valid_request_header(buf_ptr, len)
+//      checks whether a request header is well formatted
+//      updates len with the lenght of the request
+
+bool is_valid_request_header(char* buf_ptr, int& len);
+
+// is_empty_buf(ptr)
+//      checks if a buffer is empty or has data to read
+
+bool is_empty_buf(char* ptr);
+
 
 // write_to_socket(cfd, msg)
 //      wrapper around underlying c syscalls


### PR DESCRIPTION
Dockerized the server + added some functionality to the server (exit) to enable graceful exits from docker. 

To implement "exit" --- we enabled the user at the server command prompt to type commands. We did this by creating an additional thread that listens to stdin. Given we have a concurrent program which uses blocking sockets (2 threads which block per connection), we needed a way to signal the exit event to the workers. To do this, we created a series of "pipes" and updated the worker threads to unblock when "exit" was written to the pipes. In this way, we were able to gracefully end all the threads, join then back together, and clean up the OS resources.

This made it much better to use docker, since otherwise we had to continually delete the containers to free up the ports for instance rather than just running docker with a --rm tag